### PR TITLE
Modifying Dockerfile to download Toolkit Zipfile and Transfer Required Extension Files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ RUN curl -L -o toolkit.zip http://www.combodo.com/documentation/iTopDataModelToo
 	&& unzip toolkit.zip \
 	#Remove toolkit.zip file
 	&& rm toolkit.zip
+	
+#Transfer required extension files from the github repository into the iTop image
+COPY /extensions/datamodel.applicationsolution-add-attribute.xml /opt/app-root/src/extensions && \
+	 /extensions/en.dict.applicationsolution-add-attribute.php /opt/app-root/src/extensions && \
+	 /extensions/model.applicationsolution-add-attribute.php /opt/app-root/src/extensions && \
+	 /extensions/module.applicationsolution-add-attribute.php /opt/app-root/src/extensions
 
 #end of ISED customizations
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,12 @@ USER root
 
 #ISED customizations go here
 
-
+#Download toolkit.zip file
+RUN curl -L -o toolkit.zip http://www.combodo.com/documentation/iTopDataModelToolkit-2.7.zip \
+	#Unzip toolkit.zip file
+	&& unzip toolkit.zip \
+	#Remove toolkit.zip file
+	&& rm toolkit.zip
 
 #end of ISED customizations
 


### PR DESCRIPTION
The implemented changes involve the following:
- Downloading the toolkit zipfile from iTop
- Unzipping the toolkit zipfile
- Removing the toolkit zipfile from the directory after the process